### PR TITLE
Fixed broken link on the boundaryml.com/podcast/2025-07-22-multimodality page

### DIFF
--- a/2025-07-22-multimodality/README.md
+++ b/2025-07-22-multimodality/README.md
@@ -88,7 +88,7 @@ python main.py
 ## Resources
 
 - [Recording](https://youtu.be/sCScFZB4Am8)
-- [Code](https://github.com/dexhorthy/ai-that-works/tree/main/2025-07-22-multimodality)
+- [Code](https://github.com/ai-that-works/ai-that-works/tree/main/2025-07-22-multimodality)
 - [BAML Documentation](https://docs.boundaryml.com)
 - [Discord Community](https://boundaryml.com/discord)
 


### PR DESCRIPTION
This PR fixes the link in the code link on the page. 

The other code link is fine and links to the right place. 

<img width="2270" height="1584" alt="CleanShot 2025-09-16 at 11 05 42@2x" src="https://github.com/user-attachments/assets/bb59323a-39a4-47eb-adf0-e7eacd2fb43f" />
